### PR TITLE
config: validate with smartapi registration

### DIFF
--- a/biolink/open-api/TranslatorReasonersAPI.yaml
+++ b/biolink/open-api/TranslatorReasonersAPI.yaml
@@ -9,6 +9,10 @@ info:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
   termsOfService: INSERT-URL-HERE
+  x-translator: 
+    component: ARA
+    team:
+    - "Unsecret Agent"
 externalDocs:
   description: >-
     Documentation for the NCATS Biomedical Translator Reasoners web services
@@ -18,12 +22,12 @@ tags:
     description: Get supported relationships by source and target
     externalDocs:
       description: Documentation for the reasoner predicates function
-      url: http://reasonerhost.ncats.io/overview.html#predicates
+      url: http://unsecret.ncats.io/overview.html#predicates
   - name: query
     description: Query reasoner using a predefined question type
     externalDocs:
       description: Documentation for the reasoner query function
-      url: http://reasonerhost.ncats.io/overview.html#query
+      url: http://unsecret.ncats.io/overview.html#query
   - name: translator
   - name: reasoner
 paths:


### PR DESCRIPTION
We are now registered on SmartAPI.  (You must be logged in with github to see so, and the website will fail instead of telling you that.)

> https://smart-api.info/registry?q=b0ead2b28cfe5794e24845661ba45897