### PR TITLE
implement: config: web-server: trapi-disable-external-requests?, for …

### DIFF
--- a/medikanren/apps/translator-web-server.rkt
+++ b/medikanren/apps/translator-web-server.rkt
@@ -352,11 +352,17 @@ query_result_clear.addEventListener('click', function(){
                               obj)))
 
 (define (message->response msg)
-  (define broad-response (time (api-query (string-append url.broad path.query)
-                                          (hash 'message msg))))
-  (define broad-results (hash-ref broad-response 'response))
-  (printf "broad response:\n~s\n" (hash-ref broad-response 'status))
-  (pretty-print (hash-ref broad-response 'headers))
+  (define broad-results
+    (if (config-ref 'trapi-disable-external-requests?)
+      '()
+      (let* (
+          (broad-response (time (api-query (string-append url.broad path.query)
+                                              (hash 'message msg))))
+          (broad-results (hash-ref broad-response 'response)))
+        (printf "broad response:\n~s\n" (hash-ref broad-response 'status))
+        (pretty-print (hash-ref broad-response 'headers))
+        broad-results)
+      ))
   (printf "broad result size: ~s\n" (js-count broad-results))
   ;; NOTE: ignore 'results and 'knowledge_graph until we find a use for them.
   (define qgraph (hash-ref msg 'query_graph hash-empty))

--- a/medikanren/config.defaults.scm
+++ b/medikanren/config.defaults.scm
@@ -74,5 +74,11 @@
    ;; "decreases_metabolic_processing_of"
    ))
 
+  ;; Enable this flag to prevent translator-web-server.rkt 
+  ;; and open-api/ from making downstream HTTP requests.  Useful
+  ;; for functional CI tests, and for offline development.
+  (trapi-disable-external-requests?  . #f)
+
  ;; Add configuration options as new association pairs.
  )
+

--- a/medikanren/open-api/api-query.rkt
+++ b/medikanren/open-api/api-query.rkt
@@ -1,6 +1,7 @@
 #lang racket
 (provide (all-defined-out))
 (require "../mk.rkt" json net/url)
+(require "../common.rkt")
 
 (define (js-count js)
   (cond ((pair? js) (foldl + 0 (map js-count js)))
@@ -325,6 +326,8 @@ query = {
 |#
 
 ;; addition provenance/evidence for drug indication query
+(unless (config-ref 'trapi-disable-external-requests?)
+  (begin
 (pretty-print
  (time
   (api-query
@@ -384,5 +387,6 @@ query = {
                                         'type  "gene")
                                   (hash 'id    "n01"
                                         'type  "gene"))))))
+))
 
 )


### PR DESCRIPTION
  ;; Enable this flag to prevent translator-web-server.rkt 
  ;; and open-api/ from making downstream HTTP requests.  Useful
  ;; for functional CI tests, and for offline development.
  (trapi-disable-external-requests?  . #f)
