### PR TITLE
CI: precompile apps

### DIFF
--- a/medikanren/.run_ci.sh
+++ b/medikanren/.run_ci.sh
@@ -3,6 +3,23 @@ adirRepo="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 adirMk="$adirRepo/medikanren"
 adirArtifacts="$adirRepo/ci_artifacts"
 
+stepname=medikanren1_compile_trapi
+if raco make "$adirMk/apps/translator-web-server.rkt"
+then
+    echo "$stepname" > "$adirArtifacts/status/pass/$stepname"
+else
+    echo "$stepname" > "$adirArtifacts/status/fail/$stepname"
+fi
+
+stepname=medikanren1_compile_gui
+if raco make "$adirMk/apps/gui-simple-v2.rkt"
+then
+    echo "$stepname" > "$adirArtifacts/status/pass/$stepname"
+else
+    echo "$stepname" > "$adirArtifacts/status/fail/$stepname"
+fi
+
+
 # TODO: Replace this way to run tests with a way that actually
 # discovers them.  The purpose of the current way only to show that
 # tests can be run in Github Actions against real data.
@@ -13,7 +30,5 @@ then
 else
     echo medikanren_run_ci > "$adirArtifacts/status/fail/medikanren1_run_ci"
 fi
-
-
 
 

--- a/medikanren2/.run_ci.sh
+++ b/medikanren2/.run_ci.sh
@@ -3,6 +3,16 @@ adirRepo="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 adirMk="$adirRepo/medikanren2"
 adirArtifacts="$adirRepo/ci_artifacts"
 
+
+stepname=medikanren2_compile_trapi
+if raco make "$adirMk/trapi.rkt"
+then
+    echo "$stepname" > "$adirArtifacts/status/pass/$stepname"
+else
+    echo "$stepname" > "$adirArtifacts/status/fail/$stepname"
+fi
+
+
 # TODO: Replace this way to run tests with a way that actually
 # discovers them.  The purpose of the current way only to show that
 # tests can be run in Github Actions against real data.


### PR DESCRIPTION
On every CI run, check that the three currently supported apps compile:

medikanren/apps/translator-web-server.rkt
medikanren/apps/gui-simple-v2.rkt
medikanren2/trapi.rkt

(Currently, the third does not compile)
