### PR TITLE
Fix b for string search requires

### DIFF
--- a/medikanren2/string-search.rkt
+++ b/medikanren2/string-search.rkt
@@ -160,6 +160,11 @@
 ;; will exit quickly.  If no string search index is prepared, calls
 ;; to find-ids-named and find-concepts-named will fail.
 (define (string-search-init-rel rel)
-  (let* ((absd-index (hash-ref (relation-definition-info rel) 'path)))
-    (ensure-name-index-built absd-index fn-concept-name-index)
-  ))
+  (let* ((absd-index (hash-ref (relation-definition-info rel) 'path))
+         (absf-primary (path->string (simplify-path (build-path absd-index fn-cprop-primary)))))
+    ;; We check for the file to exist so that individual db/foo.rkt files can call
+    ;; string-search-init-rel, and so that common.rkt can require db/foo.rkt
+    ;; without crashing, even when the data for db/foo.rkt is not installed.
+    (when (file-exists? absf-primary)
+      (ensure-name-index-built absd-index fn-concept-name-index)
+  )))

--- a/medikanren2/string-search.rkt
+++ b/medikanren2/string-search.rkt
@@ -160,6 +160,6 @@
 ;; will exit quickly.  If no string search index is prepared, calls
 ;; to find-ids-named and find-concepts-named will fail.
 (define (string-search-init-rel rel)
-  (let* ((reld-index (hash-ref (relation-definition-info rel) 'path)))
-    (ensure-name-index-built reld-index fn-concept-name-index)
+  (let* ((absd-index (hash-ref (relation-definition-info rel) 'path)))
+    (ensure-name-index-built absd-index fn-concept-name-index)
   ))

--- a/medikanren2/test/10GB-CI/require-common-spec.rkt
+++ b/medikanren2/test/10GB-CI/require-common-spec.rkt
@@ -1,0 +1,7 @@
+#lang racket
+(require chk)
+(require "../../common.rkt")
+
+; test that we can require common.rkt without problems
+(chk
+    (#:t #t))


### PR DESCRIPTION
The idea suggested on #97 is better.  Prevents the crash, and db/foo.rkt files retain the ability to specify which relations are indexed.  (And in the future, things like which fields are indexed).

Supersedes #97.